### PR TITLE
Make DependencyFilter compatible with Nova 4.x

### DIFF
--- a/src/Filters/DependentFilter.php
+++ b/src/Filters/DependentFilter.php
@@ -198,7 +198,7 @@ class DependentFilter extends Filter
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return array_merge([
             'class' => $this->key(),


### PR DESCRIPTION
Fix error - DependentFilter::jsonSerialize() must be compatible with Laravel\Nova\Filters\Filter::jsonSerialize(): array